### PR TITLE
Added prod 'onLoginFailure' to action on login failure

### DIFF
--- a/Instagram.js
+++ b/Instagram.js
@@ -12,7 +12,8 @@ import {
   TouchableOpacity,
   KeyboardAvoidingView
 } from 'react-native'
-import qs from 'qs'
+import parse from 'querystringify';
+
 const { width, height } = Dimensions.get('window')
 
 export default class Instagram extends Component {
@@ -32,17 +33,30 @@ export default class Instagram extends Component {
   _onNavigationStateChange (webViewState) {
     const { url } = webViewState
     if (url && url.startsWith(this.props.redirectUrl)) {
-      const match = url.match(/#(.*)/)
-      if (match && match[1]) {
-        const params = qs.parse(match[1])
-        if (params.access_token) {
-          this.hide()
-          this.props.onLoginSuccess(params.access_token)
-        }
+      const results = parse(url)
+      this.hide()
+      if (results.access_token) {
+          // Keeping this to keep it backwards compatible, but also returning raw results to account for future changes.
+          this.props.onLoginSuccess(results.access_token, results)
       } else {
-        this.hide()
+          this.props.onLoginFailure(results)
       }
     }
+  }
+
+  _onMessage (reactMessage) {
+      try {
+          const json = JSON.toJSON(reactMessage.nativeEvent.data)
+          if (json && json.error_type) {
+              this.hide()
+              this.props.onLoginFailure(json)
+          }
+      }catch(err) {}
+  }
+
+  _onLoadEnd () {
+      const scriptToPostBody = "window.postMessage(document.body.innerText, '*')";
+      this.myWebView.injectJavaScript(scriptToPostBody);
   }
 
   render () {
@@ -64,6 +78,8 @@ export default class Instagram extends Component {
                 startInLoadingState
                 onNavigationStateChange={this._onNavigationStateChange.bind(this)}
                 onError={this._onNavigationStateChange.bind(this)}
+                onLoadEnd={this._onLoadEnd.bind(this)}
+                onMessage={this._onMessage.bind(this)}
               />
               <TouchableOpacity onPress={this.hide.bind(this)} style={[styles.btnStyle, this.props.styles.btnStyle]}>
                 <Image source={require('./close.png')} style={[styles.closeStyle, this.props.styles.closeStyle]} />
@@ -83,7 +99,8 @@ const propTypes = {
   styles: PropTypes.object,
   scopes: PropTypes.array,
   onLoginSuccess: PropTypes.func,
-  modalVisible: PropTypes.bool
+  modalVisible: PropTypes.bool,
+  onLoginFailure: PropTypes.func
 }
 
 const defaultProps = {
@@ -99,6 +116,9 @@ const defaultProps = {
       ],
       { cancelable: false }
     )
+  },
+  onLoginFailure: (failureJson) => {
+    console.debug(failureJson)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-instagram-login",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "instagram login",
   "main": "Instagram.js",
   "directories": {
@@ -23,5 +23,8 @@
   "bugs": {
     "url": "https://github.com/hungdev/react-native-instagram-login/issues"
   },
-  "homepage": "https://github.com/hungdev/react-native-instagram-login#readme"
+  "homepage": "https://github.com/hungdev/react-native-instagram-login#readme",
+  "dependencies": {
+    "querystringify": "^1.0.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ import InstagramLogin from 'react-native-instagram-login'
         clientId='xxxxxxxxxx'
         scopes={['public_content', 'follower_list']}
         onLoginSuccess={(token) => this.setState({ token })}
+        onLoginFailure={(data) => console.log(data)}
     />
 </View>
 


### PR DESCRIPTION
Accounts for actual results posted on redirected error url such as: http://your-redirect-uri?error=access_denied&error_reason=user_denied&error_description=The+user+denied+your+request
Will be posted as json to onLoginFailure:
{
 "error": "access_denied",
 "error_reason": "user_denied",
 "error_description": "The user denied your request"
}

We also post results that show up on webview body such as invalid redirect URI or invalid token...