### PR TITLE
Added onLoginFailre to return unsuccessful login attempts

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -45,12 +45,16 @@ export default class App extends Component<{}> {
             </View>
           )
         }
+          {this.state.failure && <View>
+            <Text style={{ margin: 10 }}>failure: {JSON.stringify(this.state.failure)}</Text>
+          </View>}
         <Ins
           ref='ins'
           clientId='c7831304b961485a938674163166e606'
           redirectUrl='https://google.com'
           scopes={['public_content+follower_list']}
           onLoginSuccess={(token) => this.setState({ token })}
+          onLoginFailure={(data)  => this.setState({failure: data})}
         />
       </View>
     );

--- a/Instagram.js
+++ b/Instagram.js
@@ -12,7 +12,7 @@ import {
   TouchableOpacity,
   KeyboardAvoidingView
 } from 'react-native'
-import parse from 'querystringify';
+import qs from 'qs'
 
 const { width, height } = Dimensions.get('window')
 
@@ -33,7 +33,8 @@ export default class Instagram extends Component {
   _onNavigationStateChange (webViewState) {
     const { url } = webViewState
     if (url && url.startsWith(this.props.redirectUrl)) {
-      const results = parse(url)
+      const match = url.match(/#(.*)/)
+      const results = qs.parse(match[1]);
       this.hide()
       if (results.access_token) {
           // Keeping this to keep it backwards compatible, but also returning raw results to account for future changes.

--- a/Instagram.js
+++ b/Instagram.js
@@ -33,8 +33,8 @@ export default class Instagram extends Component {
   _onNavigationStateChange (webViewState) {
     const { url } = webViewState
     if (url && url.startsWith(this.props.redirectUrl)) {
-      const match = url.match(/#(.*)/)
-      const results = qs.parse(match[1]);
+      const match = url.match(/(#|\?)(.*)/)
+      const results = qs.parse(match[2])
       this.hide()
       if (results.access_token) {
           // Keeping this to keep it backwards compatible, but also returning raw results to account for future changes.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,5 @@
     "url": "https://github.com/hungdev/react-native-instagram-login/issues"
   },
   "homepage": "https://github.com/hungdev/react-native-instagram-login#readme",
-  "dependencies": {
-    "querystringify": "^1.0.0"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-instagram-login",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "instagram login",
   "main": "Instagram.js",
   "directories": {
@@ -23,5 +23,8 @@
   "bugs": {
     "url": "https://github.com/hungdev/react-native-instagram-login/issues"
   },
-  "homepage": "https://github.com/hungdev/react-native-instagram-login#readme"
+  "homepage": "https://github.com/hungdev/react-native-instagram-login#readme",
+  "dependencies": {
+    "querystringify": "^1.0.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ import InstagramLogin from 'react-native-instagram-login'
         clientId='xxxxxxxxxx'
         scopes={['public_content', 'follower_list']}
         onLoginSuccess={(token) => this.setState({ token })}
+        onLoginFailure={(data) => console.log(data)}
     />
 </View>
 


### PR DESCRIPTION
Accounts for actual results posted on redirected error url such as: http://your-redirect-uri?error=access_denied&error_reason=user_denied&error_description=The+user+denied+your+request
Will be posted as json to onLoginFailure:
{
"error": "access_denied",
"error_reason": "user_denied",
"error_description": "The user denied your request"
}

We also post results that show up on webview body such as invalid redirect URI or invalid token...