### PR TITLE
Instagram API is deprecated, to start using Facebook Graph API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ pod install
 ```
 
 
-* How to get Client ID of instagram?
+* How to get Client ID of instagram (DEPRECATED)?
 
 ~go to https://www.instagram.com/developer/register/ to register instagram app. then get client ID~
 

--- a/readme.md
+++ b/readme.md
@@ -47,21 +47,32 @@ This is going to give you an access_token, which one can be used on the new Grap
 # Usage:
 
 ```javascript
+
+
+
 import InstagramLogin from 'react-native-instagram-login'
+import store from 'react-native-simple-store'
 <View>
     <TouchableOpacity onPress={()=> this.instagramLogin.show()}>
         <Text style={{color: 'white'}}>Login</Text>
     </TouchableOpacity>
     <InstagramLogin
-        ref= {ref => this.instagramLogin= ref}
+        ref='instagramLogin'
         appId='your-app-id'
         appSecret='your-app-secret'
         redirectUrl='your-redirect-Url'
-        scopes={['basic']}
-        onLoginSuccess={(token) => this.setState({ token })}
+        scopes={['user_profile', 'user_media']}
+        onLoginSuccess={ this.setIgToken }
         onLoginFailure={(data) => console.log(data)}
     />
 </View>
+
+setIgToken = async (data) =>{
+    await store.save('igToken', data.access_token)
+    await store.save('igUserId', data.user_id)
+    this.setState({ igToken: data.access_token, igUserId: data.user_id})
+  }
+
 
 ```
 
@@ -69,7 +80,8 @@ import InstagramLogin from 'react-native-instagram-login'
 
 | Property       | Type             | Description                                |
 | -------------- | ---------------- | ------------------------------------------ |
-| clientId       | PropTypes.string | Instagram App ClientId                     |
+| appId          | PropTypes.string | Instagram App_id                           |
+| appSecret      | PropTypes.string | Instagram App_secret                       |
 | responseType   | PropTypes.string | 'code' or 'token', default 'token'         |
 | scopes         | PropTypes.array  | Login Permissions                          |
 | redirectUrl    | PropTypes.string | Your redirectUrl                           |

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,12 @@ pod install
 
 * How to get Client ID of instagram?
 
-go to https://www.instagram.com/developer/register/ to register instagram app. then get client ID
+~go to https://www.instagram.com/developer/register/ to register instagram app. then get client ID~
+
+Go to https://developers.facebook.com/docs/instagram-api/getting-started to register new app, and get app_id and app_secret.
+
+This is going to give you an access_token, which one can be used on the new Graph Api, go to https://developers.facebook.com/docs/instagram-basic-display-api/guides/getting-profiles-and-media for docs. 
+
 
 # Usage:
 
@@ -49,7 +54,8 @@ import InstagramLogin from 'react-native-instagram-login'
     </TouchableOpacity>
     <InstagramLogin
         ref= {ref => this.instagramLogin= ref}
-        clientId='your-client-ID'
+        appId='your-app-id'
+        appSecret='your-app-secret'
         redirectUrl='your-redirect-Url'
         scopes={['basic']}
         onLoginSuccess={(token) => this.setState({ token })}


### PR DESCRIPTION
In this pull request, the URI to get code from API (throw login as usually), is changed, the flow that follows the plugin now is:

->Go to https://api.instagram.com/oauth/authorize with app_id, app_secret, redirect_uri, response_type and scope
->Once we get the code from the step before, fetch POST endpoint to get access_token at https://api.instagram.com/oauth/access_token, with app_id, app_secret, grant_type, redirect_uri and code.
->Then the response object must be like { access_token: ' ', user_id: ' ' }, this object will be dispatch to the onLoginSuccess function that you give as prop to InstagramLogin Component.
-> Finally, with access_token we will be able to get data from the new Facebook Graph API. (remember that all olds endpoint of instagram developer service are deprecated and are not working anymore)