### PR TITLE
Add file property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "files": [
+    "Instagram.js",
+    "assets"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hungdev/react-native-instagram-login.git"


### PR DESCRIPTION
When I download this package, `Example` and other unused gif files are included in the `node_modules` folder.
By adding a `file` property in the `package.json`, it limits the files included in the node modules. (package.json and README.md are included by default)