### PR TITLE
 Change webview from dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "homepage": "https://github.com/hungdev/react-native-instagram-login#readme",
   "dependencies": {
     "qs": "6.9.4",
-    "react-native-webview": "^10.9.3",
     "axios": "^0.19.2"
+  },
+  "peerDependencies":{
+    "react-native-webview": "^11.2.3"
   }
 }


### PR DESCRIPTION
The situation was like this: 
I had already installed "react-native-webview" and installing "react-native-instagram-login" causes App crash.
adding >>> "peerDependencies": {"react-native-webview": "^11.2.3"} in package.json solve this problem.
It will be useful  for future users too
