### PR TITLE
explicit withCredentials: false solves 403 return from IG servers

### DIFF
--- a/Instagram.js
+++ b/Instagram.js
@@ -72,6 +72,7 @@ export default class Instagram extends Component {
           let http = axios.create({
             baseURL: 'https://api.instagram.com/oauth/access_token',
             headers: headers,
+            withCredentials: false,
           });
           let form = new FormData();
           form.append('client_id', appId);


### PR DESCRIPTION
Solves https://github.com/hungdev/react-native-instagram-login/issues/120 w/o changing axios version.

Note: Axios 0.19.2 is deprecated.